### PR TITLE
Fix build on 2.11

### DIFF
--- a/sic.c
+++ b/sic.c
@@ -182,8 +182,7 @@ int argc;
 char *argv[];
 {
 	struct timeval tv;
-	char *user = getenv("USER");;
-	static char vermsg[256];
+	char *user = getenv("USER");
 	int n;
 	fd_set rd;
 


### PR DESCRIPTION
Removed extra unused static variable which 2.11 cc doesn't have support for.

Tested on a real PDP11/53 running 2.11 BSD patch 481.